### PR TITLE
Joining domain with a specified Hostip causes an error

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -219,8 +219,8 @@ appSetup () {
   #Check if DOMAIN_NETBIOS <15 chars and contains no "."
   if [[ "${#DOMAIN_NETBIOS}" -gt 15 ]]; then echo "DOMAIN_NETBIOS too long => exiting" ; exit 1 ; fi
   if [[ "${DOMAIN_NETBIOS}" == *"."* ]]; then echo "DOMAIN_NETBIOS contains forbiden char    .     => exiting" ; exit 1 ; fi
-  if [[ "${HOSTIP}" != "NONE" ]]; then ARGS_SAMBA_TOOL+=("--host-ip=${HOSTIP%/*}") ; fi
-  if [[ "${HOSTIPV6}" != "NONE" ]]; then ARGS_SAMBA_TOOL+=("--host-ip6=${HOSTIPV6}") ;  fi
+  if [[ "${HOSTIP}" != "NONE" ]] && [[ "${JOIN}" != true ]]; then ARGS_SAMBA_TOOL+=("--host-ip=${HOSTIP%/*}") ; fi
+  if [[ "${HOSTIPV6}" != "NONE" ]] && [[ "${JOIN}" != true ]]; then ARGS_SAMBA_TOOL+=("--host-ip6=${HOSTIPV6}") ;  fi
   if [[ "${JOIN_SITE}" != "Default-First-Site-Name" ]]; then ARGS_SAMBA_TOOL+=("--site=${JOIN_SITE}") ; fi
   if [[ "${ENABLE_DNSFORWARDER}" != "NONE" ]]; then ARGS_SAMBA_TOOL+=("--option=dns forwarder=${ENABLE_DNSFORWARDER}") ; fi
   if [[ "${ENABLE_DYNAMIC_PORTRANGE}" != "NONE" ]]; then ARGS_SAMBA_TOOL+=("--option=rpc server dynamic port range=${ENABLE_DYNAMIC_PORTRANGE}") ; fi


### PR DESCRIPTION
When joining a domain and specifying HOSTIP, an error is generated about --host-ip not being a valid argument from the join process and it fails.

Joining with this change works and does not cause errors, but DNS entries are created with the local ip address of the docker contain (172.something).

Adding the environment configuration:

BIND_INTERFACES_ENABLE=true
BIND_INTERFACES=127.0.0.1 PUT_HOST_IP_HERE

and then restating the container makes it use the correct ip.

I manually removed the 172.something addresses (using Windows DNS Manager tool) and then updated the DNS with the right addresses, but it may happen automatically.

